### PR TITLE
gir: generate better output for `document_new_file`

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -169,7 +169,7 @@ Geany_1_0_tmp_gir_INCLUDES      = $(GTK_GIR) GLib-2.0 GObject-2.0
 Geany_1_0_tmp_gir_CFLAGS        = $(gir_common_cflags) \
                                   -DScintillaObject=GeanyScintillaScintillaObject
 Geany_1_0_tmp_gir_LIBS          = ../src/libgeany.la
-Geany_1_0_tmp_gir_FILES         = geany-gtkdoc.h
+Geany_1_0_tmp_gir_FILES         = geany-gtkdoc-tmp.h
 Geany_1_0_tmp_gir_SCANNERFLAGS  = $(SCANNERFLAGS) --include-uninstalled=GeanyScintilla-1.0.gir
 
 GeanyScintilla_1_0_tmp_gir_NAMESPACE    = GeanyScintilla
@@ -189,6 +189,11 @@ gir_DATA        = Geany-1.0.gir GeanyScintilla-1.0.gir
 typelibdir      = $(libdir)/girepository-1.0
 typelib_DATA    = Geany-1.0.typelib GeanyScintilla-1.0.typelib
 
+geany-gtkdoc-tmp.h: geany-gtkdoc.h
+	$(AM_V_GEN) $(SED) \
+		-e 's,document_new_file,document_gidoccreatefilefunc,g' \
+		$< > $@
+
 geany-sciwrappers-gtkdoc-tmp.h: geany-sciwrappers-gtkdoc.h
 	$(AM_V_GEN) $(SED) \
 		-e 's,sci_,scintilla_object__GI__MARK_,g' \
@@ -202,6 +207,7 @@ GeanyScintilla-1.0.gir: GeanyScintilla-1.0-tmp.gir
 Geany-1.0.gir: Geany-1.0-tmp.gir
 	$(AM_V_GEN) $(SED) \
 		-e 's,GeanyScintillaScintillaObject,ScintillaObject,g' \
+		-e 's,gidoccreatefilefunc,new_file,g' \
 		$< > $@
 
 ALL_LOCAL_TARGETS += $(gir_DATA) $(typelib_DATA)
@@ -209,7 +215,7 @@ ALL_LOCAL_TARGETS += $(gir_DATA) $(typelib_DATA)
 CLEANFILES = \
 	$(gir_DATA) $(typelib_DATA) \
 	Geany-1.0-tmp.gir GeanyScintilla-1.0-tmp.gir \
-	geany-sciwrappers-gtkdoc-tmp.h
+	geany-gtkdoc-tmp.h geany-sciwrappers-gtkdoc-tmp.h
 
 include $(INTROSPECTION_MAKEFILE)
 


### PR DESCRIPTION
`g-ir-scanner` treats anything with `_new` in the name as a constructor which, strictly speaking, `document_new_file` is not. Rename this function to prevent `g-ir-scanner` from seeing it, and then rename it back in the GIR XML file so that the correct typelib is compiled and the correct name is in the installed GIR file. This hack is already used for other symbols.

The result is a static function `Document.new_file` which seems to be reasonable in languages such as Vala and Python.

Closes #1094
